### PR TITLE
Support principalID and general cloud access and identity to Azure from Azure

### DIFF
--- a/manifests/wayfinder-cloud-identity.yml.tpl
+++ b/manifests/wayfinder-cloud-identity.yml.tpl
@@ -9,3 +9,4 @@ spec:
   azure:
     clientID: ${client_id}
     tenantID: ${tenant_id}
+    principalID: ${wayfinder_principal_id}

--- a/manifests/wayfinder-values.yml.tpl
+++ b/manifests/wayfinder-values.yml.tpl
@@ -37,3 +37,4 @@ ui:
 workloadIdentity:
   azure:
     clientID: ${wayfinder_client_id}
+    principalID: ${wayfinder_principal_id}

--- a/modules/cloudaccess/README.md
+++ b/modules/cloudaccess/README.md
@@ -1,6 +1,42 @@
 <!-- BEGIN_TF_DOCS -->
-# Terraform Module:
-This Terraform Module can be used to provision the roles that wayfinder uses to manage resources in azure
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.74.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=3.74.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_federated_identity_credential.federated_identity_aws](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_federated_identity_credential.federated_identity_gcp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_resource_group.federated_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.cloudinfo](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cloudinfo_federated](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.clustermanager](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.clustermanager_federated](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.dnszonemanager](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.dnszonemanager_federated](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.networkmanager](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.networkmanager_federated](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.cloudinfo](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.clustermanager](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.dnszonemanager](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.networkmanager](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_user_assigned_identity.federated_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [azurerm_subscription.primary](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
@@ -15,7 +51,7 @@ This Terraform Module can be used to provision the roles that wayfinder uses to 
 | <a name="input_wayfinder_identity_aws_issuer"></a> [wayfinder\_identity\_aws\_issuer](#input\_wayfinder\_identity\_aws\_issuer) | Issuer URL to trust to verify Wayfinder's AWS identity. Populate when Wayfinder is running on AWS with IRSA. | `string` | `""` | no |
 | <a name="input_wayfinder_identity_aws_role_arn"></a> [wayfinder\_identity\_aws\_role\_arn](#input\_wayfinder\_identity\_aws\_role\_arn) | ARN of Wayfinder's identity to give access to. Populate when Wayfinder is running on AWS with IRSA. | `string` | `""` | no |
 | <a name="input_wayfinder_identity_aws_subject"></a> [wayfinder\_identity\_aws\_subject](#input\_wayfinder\_identity\_aws\_subject) | Subject to trust to verify Wayfinder's AWS identity. Populate when Wayfinder is running on AWS with IRSA. | `string` | `""` | no |
-| <a name="input_wayfinder_identity_azure_client_id"></a> [wayfinder\_identity\_azure\_client\_id](#input\_wayfinder\_identity\_azure\_client\_id) | Client ID of Wayfinder's Azure AD managed identity to give access to. Populate when Wayfinder is running on Azure with AzureAD Workload Identity or when using a credential-based Azure identity. | `string` | `""` | no |
+| <a name="input_wayfinder_identity_azure_principal_id"></a> [wayfinder\_identity\_azure\_principal\_id](#input\_wayfinder\_identity\_azure\_principal\_id) | Principal ID of Wayfinder's Azure AD managed identity to give access to. Populate when Wayfinder is running on Azure with AzureAD Workload Identity or when using a credential-based Azure identity. | `string` | `""` | no |
 | <a name="input_wayfinder_identity_azure_tenant_id"></a> [wayfinder\_identity\_azure\_tenant\_id](#input\_wayfinder\_identity\_azure\_tenant\_id) | Tenant ID of Wayfinder's Azure AD managed identity to give access to. Populate when Wayfinder is running on Azure with AzureAD Workload Identity. | `string` | `""` | no |
 | <a name="input_wayfinder_identity_gcp_service_account"></a> [wayfinder\_identity\_gcp\_service\_account](#input\_wayfinder\_identity\_gcp\_service\_account) | Email address of Wayfinder's GCP service account to give access to. Populate when Wayfinder is running on GCP with Workload Identity. | `string` | `""` | no |
 | <a name="input_wayfinder_identity_gcp_service_account_id"></a> [wayfinder\_identity\_gcp\_service\_account\_id](#input\_wayfinder\_identity\_gcp\_service\_account\_id) | Numerical ID of Wayfinder's GCP service account to give access to. Populate when Wayfinder is running on GCP with Workload Identity. | `string` | `""` | no |

--- a/modules/cloudaccess/examples/azure-to-azure/main.tf
+++ b/modules/cloudaccess/examples/azure-to-azure/main.tf
@@ -1,11 +1,11 @@
 module "wayfinder_cloudaccess" {
   source = "../../"
 
-  resource_suffix                    = "app1-nonprod"
-  wayfinder_identity_azure_client_id = "87654321-dcba-10fe-abcd-012345678901"
-  wayfinder_identity_azure_tenant_id = "12345678-abcd-ef01-dcba-012345678901"
-  enable_cluster_manager             = true
-  enable_dns_zone_manager            = true
-  enable_network_manager             = true
-  enable_cloud_info                  = false
+  resource_suffix                       = "app1-nonprod"
+  wayfinder_identity_azure_principal_id = "87654321-dcba-10fe-abcd-012345678901"
+  wayfinder_identity_azure_tenant_id    = "12345678-abcd-ef01-dcba-012345678901"
+  enable_cluster_manager                = true
+  enable_dns_zone_manager               = true
+  enable_network_manager                = true
+  enable_cloud_info                     = false
 }

--- a/modules/cloudaccess/variables.tf
+++ b/modules/cloudaccess/variables.tf
@@ -4,9 +4,9 @@ variable "resource_suffix" {
   type        = string
 }
 
-variable "wayfinder_identity_azure_client_id" {
+variable "wayfinder_identity_azure_principal_id" {
   default     = ""
-  description = "Client ID of Wayfinder's Azure AD managed identity to give access to. Populate when Wayfinder is running on Azure with AzureAD Workload Identity or when using a credential-based Azure identity."
+  description = "Principal ID of Wayfinder's Azure AD managed identity to give access to. Populate when Wayfinder is running on Azure with AzureAD Workload Identity or when using a credential-based Azure identity."
   type        = string
 }
 

--- a/modules/cloudaccess/wf_cloud_info.tf
+++ b/modules/cloudaccess/wf_cloud_info.tf
@@ -1,3 +1,7 @@
+locals {
+  cloudinfo_definition = jsondecode(file("${path.module}/wf_cloud_info_definition.json"))
+}
+
 resource "azurerm_role_definition" "cloudinfo" {
   count = var.enable_cloud_info ? 1 : 0
 
@@ -5,23 +9,16 @@ resource "azurerm_role_definition" "cloudinfo" {
   scope = data.azurerm_subscription.primary.id
 
   permissions {
-    actions = [
-      "Microsoft.Commerce/RateCard/read",
-      "Microsoft.Compute/virtualMachines/vmSizes/read",
-      "Microsoft.ContainerService/containerServices/read",
-      "Microsoft.Resources/providers/read",
-      "Microsoft.Resources/subscriptions/locations/read",
-      "Microsoft.Resources/subscriptions/providers/read"
-    ]
+    actions = local.cloudinfo_definition.actions
   }
 }
 
 resource "azurerm_role_assignment" "cloudinfo" {
-  count = var.enable_cloud_info && var.wayfinder_identity_azure_client_id != "" ? 1 : 0
+  count = var.enable_cloud_info && var.wayfinder_identity_azure_principal_id != "" ? 1 : 0
 
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = azurerm_role_definition.cloudinfo[0].name
-  principal_id         = var.wayfinder_identity_azure_client_id
+  principal_id         = var.wayfinder_identity_azure_principal_id
 
   depends_on = [
     azurerm_role_definition.cloudinfo[0]

--- a/modules/cloudaccess/wf_cloud_info_definition.json
+++ b/modules/cloudaccess/wf_cloud_info_definition.json
@@ -1,0 +1,10 @@
+{
+    "actions": [
+        "Microsoft.Commerce/RateCard/read",
+        "Microsoft.Compute/virtualMachines/vmSizes/read",
+        "Microsoft.ContainerService/containerServices/read",
+        "Microsoft.Resources/providers/read",
+        "Microsoft.Resources/subscriptions/locations/read",
+        "Microsoft.Resources/subscriptions/providers/read"
+    ]
+}

--- a/modules/cloudaccess/wf_cluster_manager.tf
+++ b/modules/cloudaccess/wf_cluster_manager.tf
@@ -1,45 +1,24 @@
+locals {
+  clustermanager_definition = jsondecode(file("${path.module}/wf_cluster_manager_definition.json"))
+}
+
 resource "azurerm_role_definition" "clustermanager" {
   count = var.enable_cluster_manager ? 1 : 0
 
   name  = "${local.resource_prefix}clustermanager${local.resource_suffix}"
   scope = data.azurerm_subscription.primary.id
+
   permissions {
-    actions = [
-      "Microsoft.Resources/subscriptions/providers/read",
-      "Microsoft.Resources/subscriptions/resourceGroups/read",
-      "Microsoft.Resources/subscriptions/resourceGroups/write",
-      "Microsoft.Resources/subscriptions/resourceGroups/delete",
-      "Microsoft.ContainerService/managedClusters/agentPools/read",
-      "Microsoft.ContainerService/managedClusters/agentPools/write",
-      "Microsoft.ContainerService/managedClusters/agentPools/delete",
-      "Microsoft.ContainerService/managedClusters/read",
-      "Microsoft.ContainerService/managedClusters/write",
-      "Microsoft.ContainerService/managedClusters/delete",
-      "Microsoft.ContainerService/managedClusters/listClusterAdminCredential/action",
-      "Microsoft.ManagedIdentity/userAssignedIdentities/read",
-      "Microsoft.ManagedIdentity/userAssignedIdentities/write",
-      "Microsoft.ManagedIdentity/userAssignedIdentities/delete",
-      "Microsoft.Authorization/roleAssignments/read",
-      "Microsoft.Authorization/roleAssignments/write",
-      "Microsoft.Authorization/roleAssignments/delete",
-      "Microsoft.ContainerService/register/action",
-      "Microsoft.Compute/register/action",
-      "Microsoft.Compute/unregister/action",
-      "Microsoft.Resources/providers/read",
-      "Microsoft.Storage/register/action",
-      "Microsoft.Features/register/action",
-      "Microsoft.Features/providers/features/register/action",
-      "Microsoft.Network/virtualNetworks/subnets/join/action"
-    ]
+    actions = local.clustermanager_definition.actions
   }
 }
 
 resource "azurerm_role_assignment" "clustermanager" {
-  count = var.enable_cluster_manager && var.wayfinder_identity_azure_client_id != "" ? 1 : 0
+  count = var.enable_cluster_manager && var.wayfinder_identity_azure_principal_id != "" ? 1 : 0
 
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = azurerm_role_definition.clustermanager[0].name
-  principal_id         = var.wayfinder_identity_azure_client_id
+  principal_id         = var.wayfinder_identity_azure_principal_id
 
   depends_on = [
     azurerm_role_definition.clustermanager[0]

--- a/modules/cloudaccess/wf_cluster_manager_definition.json
+++ b/modules/cloudaccess/wf_cluster_manager_definition.json
@@ -1,0 +1,30 @@
+{
+    "actions": [
+        "Microsoft.Authorization/roleAssignments/read",
+        "Microsoft.Authorization/roleDefinitions/read",
+        "Microsoft.Authorization/roleAssignments/write",
+        "Microsoft.Authorization/roleAssignments/delete",
+        "Microsoft.Resources/subscriptions/providers/read",
+        "Microsoft.Resources/subscriptions/resourceGroups/read",
+        "Microsoft.Resources/subscriptions/resourceGroups/write",
+        "Microsoft.Resources/subscriptions/resourceGroups/delete",
+        "Microsoft.ContainerService/managedClusters/agentPools/read",
+        "Microsoft.ContainerService/managedClusters/agentPools/write",
+        "Microsoft.ContainerService/managedClusters/agentPools/delete",
+        "Microsoft.ContainerService/managedClusters/read",
+        "Microsoft.ContainerService/managedClusters/write",
+        "Microsoft.ContainerService/managedClusters/delete",
+        "Microsoft.ContainerService/managedClusters/listClusterAdminCredential/action",
+        "Microsoft.ManagedIdentity/userAssignedIdentities/read",
+        "Microsoft.ManagedIdentity/userAssignedIdentities/write",
+        "Microsoft.ManagedIdentity/userAssignedIdentities/delete",
+        "Microsoft.ContainerService/register/action",
+        "Microsoft.Compute/register/action",
+        "Microsoft.Compute/unregister/action",
+        "Microsoft.Resources/providers/read",
+        "Microsoft.Storage/register/action",
+        "Microsoft.Features/register/action",
+        "Microsoft.Features/providers/features/register/action",
+        "Microsoft.Network/virtualNetworks/subnets/join/action"
+    ]
+}

--- a/modules/cloudaccess/wf_dnszone_manager.tf
+++ b/modules/cloudaccess/wf_dnszone_manager.tf
@@ -1,3 +1,7 @@
+locals {
+  dnszonemanager_definition = jsondecode(file("${path.module}/wf_dnszone_manager_definition.json"))
+}
+
 resource "azurerm_role_definition" "dnszonemanager" {
   count = var.enable_dns_zone_manager ? 1 : 0
 
@@ -5,28 +9,16 @@ resource "azurerm_role_definition" "dnszonemanager" {
   scope = data.azurerm_subscription.primary.id
 
   permissions {
-    actions = [
-      "Microsoft.Resources/subscriptions/providers/read",
-      "Microsoft.Resources/subscriptions/resourceGroups/read",
-      "Microsoft.Resources/subscriptions/resourceGroups/write",
-      "Microsoft.Resources/subscriptions/resourceGroups/delete",
-      "Microsoft.Network/dnszones/read",
-      "Microsoft.Network/dnszones/write",
-      "Microsoft.Network/dnszones/delete",
-      "Microsoft.Network/dnszones/recordsets/read",
-      "Microsoft.Network/dnszones/NS/read",
-      "Microsoft.Network/dnszones/NS/write",
-      "Microsoft.Network/dnszones/NS/delete"
-    ]
+    actions = local.dnszonemanager_definition.actions
   }
 }
 
 resource "azurerm_role_assignment" "dnszonemanager" {
-  count = var.enable_dns_zone_manager && var.wayfinder_identity_azure_client_id != "" ? 1 : 0
+  count = var.enable_dns_zone_manager && var.wayfinder_identity_azure_principal_id != "" ? 1 : 0
 
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = azurerm_role_definition.dnszonemanager[0].name
-  principal_id         = var.wayfinder_identity_azure_client_id
+  principal_id         = var.wayfinder_identity_azure_principal_id
 
   depends_on = [
     azurerm_role_definition.dnszonemanager[0]

--- a/modules/cloudaccess/wf_dnszone_manager_definition.json
+++ b/modules/cloudaccess/wf_dnszone_manager_definition.json
@@ -1,0 +1,17 @@
+{
+    "actions": [
+        "Microsoft.Authorization/roleAssignments/read",
+        "Microsoft.Authorization/roleDefinitions/read",
+        "Microsoft.Resources/subscriptions/providers/read",
+        "Microsoft.Resources/subscriptions/resourceGroups/read",
+        "Microsoft.Resources/subscriptions/resourceGroups/write",
+        "Microsoft.Resources/subscriptions/resourceGroups/delete",
+        "Microsoft.Network/dnszones/read",
+        "Microsoft.Network/dnszones/write",
+        "Microsoft.Network/dnszones/delete",
+        "Microsoft.Network/dnszones/recordsets/read",
+        "Microsoft.Network/dnszones/NS/read",
+        "Microsoft.Network/dnszones/NS/write",
+        "Microsoft.Network/dnszones/NS/delete"
+    ]
+}

--- a/modules/cloudaccess/wf_network_manager.tf
+++ b/modules/cloudaccess/wf_network_manager.tf
@@ -1,3 +1,7 @@
+locals {
+  networkmanager_definition = jsondecode(file("${path.module}/wf_network_manager_definition.json"))
+}
+
 resource "azurerm_role_definition" "networkmanager" {
   count = var.enable_network_manager ? 1 : 0
 
@@ -5,27 +9,16 @@ resource "azurerm_role_definition" "networkmanager" {
   scope = data.azurerm_subscription.primary.id
 
   permissions {
-    actions = [
-      "Microsoft.Authorization/*/read",
-      "Microsoft.Insights/alertRules/*",
-      "Microsoft.Network/*",
-      "Microsoft.ResourceHealth/availabilityStatuses/read",
-      "Microsoft.Resources/deployments/*",
-      "Microsoft.Resources/subscriptions/resourceGroups/read",
-      "Microsoft.Resources/subscriptions/resourceGroups/write",
-      "Microsoft.Resources/subscriptions/resourceGroups/delete",
-      "Microsoft.Support/*",
-      "Microsoft.Resources/subscriptions/providers/read"
-    ]
+    actions = local.networkmanager_definition.actions
   }
 }
 
 resource "azurerm_role_assignment" "networkmanager" {
-  count = var.enable_network_manager && var.wayfinder_identity_azure_client_id != "" ? 1 : 0
+  count = var.enable_network_manager && var.wayfinder_identity_azure_principal_id != "" ? 1 : 0
 
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = azurerm_role_definition.networkmanager[0].name
-  principal_id         = var.wayfinder_identity_azure_client_id
+  principal_id         = var.wayfinder_identity_azure_principal_id
 
   depends_on = [
     azurerm_role_definition.networkmanager[0]

--- a/modules/cloudaccess/wf_network_manager_definition.json
+++ b/modules/cloudaccess/wf_network_manager_definition.json
@@ -1,0 +1,14 @@
+{
+    "actions": [
+        "Microsoft.Authorization/*/read",
+        "Microsoft.Insights/alertRules/*",
+        "Microsoft.Network/*",
+        "Microsoft.ResourceHealth/availabilityStatuses/read",
+        "Microsoft.Resources/deployments/*",
+        "Microsoft.Resources/subscriptions/resourceGroups/read",
+        "Microsoft.Resources/subscriptions/resourceGroups/write",
+        "Microsoft.Resources/subscriptions/resourceGroups/delete",
+        "Microsoft.Support/*",
+        "Microsoft.Resources/subscriptions/providers/read"
+    ]
+}

--- a/wayfinder-cloudaccess.tf
+++ b/wayfinder-cloudaccess.tf
@@ -65,10 +65,11 @@ resource "kubectl_manifest" "wayfinder_cloud_identity_main" {
   depends_on = [helm_release.wayfinder]
 
   yaml_body = templatefile("${path.module}/manifests/wayfinder-cloud-identity.yml.tpl", {
-    name        = "cloudidentity-azure"
-    description = "Cloud managed identity"
-    client_id   = azurerm_user_assigned_identity.wayfinder_main.client_id
-    tenant_id   = data.azurerm_subscription.current.tenant_id
+    name         = "cloudidentity-azure"
+    description  = "Cloud managed identity"
+    client_id    = azurerm_user_assigned_identity.wayfinder_main.client_id
+    tenant_id    = data.azurerm_subscription.current.tenant_id
+    principal_id = azurerm_user_assigned_identity.wayfinder_main.principal_id
   })
 }
 

--- a/wayfinder.tf
+++ b/wayfinder.tf
@@ -127,6 +127,7 @@ resource "helm_release" "wayfinder" {
       storage_class                 = "managed"
       ui_hostname                   = var.wayfinder_domain_name_ui
       wayfinder_client_id           = azurerm_user_assigned_identity.wayfinder_main.client_id
+      wayfinder_principal_id        = azurerm_user_assigned_identity.wayfinder_main.principal_id
       wayfinder_instance_identifier = var.wayfinder_instance_id
     })
   ]


### PR DESCRIPTION
tested locally off this branch:
```
11:15 $ terraform plan
╷
│ Error: Module source has changed
│
│   on main.tf line 2, in module "wayfinder_cloudaccess":
│    2:   source = "github.com/appvia/terraform-azurerm-wayfinder//modules/cloudaccess?ref=input-from-azure-on-azure"
│
│ The source address was changed since this module was installed. Run "terraform init" to install all modules required by this
│ configuration.
╵
✘-1 ~/go/src/github.com/appvia/wayfinder/terraform/local/azure
11:17 $ terraform init

Initializing the backend...
Initializing modules...
Downloading git::https://github.com/appvia/terraform-azurerm-wayfinder.git?ref=input-from-azure-on-azure for wayfinder_cloudaccess...
- wayfinder_cloudaccess in .terraform/modules/wayfinder_cloudaccess/modules/cloudaccess

Initializing provider plugins...
- Reusing previous version of hashicorp/azurerm from the dependency lock file
- Using previously-installed hashicorp/azurerm v3.76.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
✔ ~/go/src/github.com/appvia/wayfinder/terraform/local/azure
11:17 $ terraform plan
module.wayfinder_cloudaccess.data.azurerm_subscription.primary: Reading...
module.wayfinder_cloudaccess.data.azurerm_subscription.primary: Read complete after 2s [id=/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba]
module.wayfinder_cloudaccess.azurerm_role_definition.networkmanager[0]: Refreshing state... [id=/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba/providers/Microsoft.Authorization/roleDefinitions/7d398934-270e-9f36-be36-766c3c9cf8ba|/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba]
module.wayfinder_cloudaccess.azurerm_role_definition.dnszonemanager[0]: Refreshing state... [id=/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba/providers/Microsoft.Authorization/roleDefinitions/eedafcdc-9b19-0ee0-0973-5e5bc88e6094|/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba]
module.wayfinder_cloudaccess.azurerm_role_definition.clustermanager[0]: Refreshing state... [id=/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba/providers/Microsoft.Authorization/roleDefinitions/ac8b00a3-4d06-42af-5edf-93f717c97837|/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba]
module.wayfinder_cloudaccess.azurerm_role_assignment.dnszonemanager[0]: Refreshing state... [id=/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba/providers/Microsoft.Authorization/roleAssignments/9abd8a58-090c-1705-42a2-f83bed067c4a]
module.wayfinder_cloudaccess.azurerm_role_assignment.clustermanager[0]: Refreshing state... [id=/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba/providers/Microsoft.Authorization/roleAssignments/85cae773-49b8-2114-37d4-0d2547378aa8]
module.wayfinder_cloudaccess.azurerm_role_assignment.networkmanager[0]: Refreshing state... [id=/subscriptions/c9757c60-ea81-44e7-a7a3-022874e014ba/providers/Microsoft.Authorization/roleAssignments/82dedf2b-6123-ba41-f51c-97d3a8e5f798]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```